### PR TITLE
Handle missing kaleido dependency for chart exports

### DIFF
--- a/app/components/charts.py
+++ b/app/components/charts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 from typing import Iterable, Tuple
 
 import pandas as pd
@@ -10,6 +11,17 @@ import plotly.graph_objects as go
 
 
 PX_TEMPLATE = "plotly_white"
+_KALEIDO_AVAILABLE = importlib.util.find_spec("kaleido") is not None
+
+
+class ChartExportError(RuntimeError):
+    """Raised when chart exports cannot be produced."""
+
+
+def _kaleido_available() -> bool:
+    """Return whether the optional kaleido dependency is installed."""
+
+    return _KALEIDO_AVAILABLE
 
 
 def time_series(df: pd.DataFrame, *, x: str, y: str, title: str, unit: str) -> go.Figure:
@@ -46,7 +58,24 @@ def scatter_density(df: pd.DataFrame, *, x: str, y: str, text: str, title: str) 
 
 
 def figures_to_png(figures: Iterable[go.Figure]) -> Tuple[bytes, ...]:
-    """Convert Plotly figures to PNG byte strings for exports."""
+    """Convert Plotly figures to PNG byte strings for exports.
 
-    return tuple(fig.to_image(format="png", scale=2) for fig in figures)
+    Raises:
+        ChartExportError: If the optional ``kaleido`` dependency is missing or the
+            conversion fails for another reason.
+    """
+
+    if not _kaleido_available():
+        raise ChartExportError(
+            "PNGエクスポートにはkaleidoパッケージが必要です。現在は利用できないため、"
+            "画像出力をスキップします。"
+        )
+
+    images = []
+    for fig in figures:
+        try:
+            images.append(fig.to_image(format="png", scale=2))
+        except (ValueError, RuntimeError) as exc:  # pragma: no cover - defensive
+            raise ChartExportError("チャートのPNG変換に失敗しました。") from exc
+    return tuple(images)
 


### PR DESCRIPTION
## Summary
- add a dedicated ChartExportError and kaleido availability check before rendering PNGs
- warn users inside the export tab when chart images cannot be generated and disable PPTX downloads in that case

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d67eeb461483238b7019092a42a2c7