### PR TITLE
Allow configuring e-Stat key via environment variable

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -13,7 +13,7 @@ Streamlit ベースで業種・地域を入力すると、e-Stat API から統�
    pip install -r requirements.txt
    ```
 
-2. `.streamlit/secrets.toml` に API キーを設定します。
+2. `.streamlit/secrets.toml` に API キーを設定します。環境変数 `ESTAT_APP_ID` に設定しても読み込まれます。
 
    ```toml
    ESTAT_APP_ID = "あなたのe-StatアプリID"

--- a/app/components/layout.py
+++ b/app/components/layout.py
@@ -84,6 +84,10 @@ def sidebar_controls(
         default_api_key = st.session_state["estat_api_key"]
     elif "ESTAT_APP_ID" in st.secrets:
         default_api_key = st.secrets["ESTAT_APP_ID"]
+    else:
+        from os import getenv
+
+        default_api_key = getenv("ESTAT_APP_ID", "")
 
     api_key = st.sidebar.text_input(
         "e-Stat APIキー",

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Dict, Tuple
 
@@ -27,6 +28,8 @@ def _load_estat_client(api_key: str | None) -> EstatClient:
     app_id = (api_key or "").strip()
     if not app_id and "ESTAT_APP_ID" in st.secrets:
         app_id = st.secrets["ESTAT_APP_ID"].strip()
+    if not app_id:
+        app_id = os.getenv("ESTAT_APP_ID", "").strip()
     if not app_id:
         raise RuntimeError("e-StatのAPIキーが未設定です。サイドバーから入力してください。")
     return EstatClient(app_id)


### PR DESCRIPTION
## Summary
- allow the Streamlit app to fall back to the ESTAT_APP_ID environment variable when no sidebar or secret value is provided
- expose the same fallback in the sidebar default value so the input field is pre-filled when possible
- document the new configuration option in the setup instructions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d696c848ec83238f89201fbce41fe2