### PR TITLE
Ensure e-Stat API key persists across reruns

### DIFF
--- a/app/components/layout.py
+++ b/app/components/layout.py
@@ -95,8 +95,11 @@ def sidebar_controls(
         type="password",
         help="e-StatのアプリケーションIDを入力してください。",
     )
+    api_key = api_key.strip()
     if api_key:
         st.session_state["estat_api_key"] = api_key
+    elif "estat_api_key" in st.session_state and st.session_state["estat_api_key"]:
+        api_key = st.session_state["estat_api_key"]
     advanced = st.sidebar.expander("高度な設定")
     with advanced:
         st.caption("sample_queries.json を編集することで統計表を追加できます。")

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -26,6 +26,10 @@ def load_presets() -> Dict[str, Dict[str, str]]:
 
 def _load_estat_client(api_key: str | None) -> EstatClient:
     app_id = (api_key or "").strip()
+    if not app_id and st is not None and "estat_api_key" in st.session_state:
+        stored_key = str(st.session_state.get("estat_api_key", "")).strip()
+        if stored_key:
+            app_id = stored_key
     if not app_id and "ESTAT_APP_ID" in st.secrets:
         app_id = st.secrets["ESTAT_APP_ID"].strip()
     if not app_id:


### PR DESCRIPTION
## Summary
- retain the e-Stat API key from Streamlit session state when the password field reruns empty
- fall back to the stored session key when constructing the EstatClient so cached credentials are reused

## Testing
- not run (Streamlit UI only)


------
https://chatgpt.com/codex/tasks/task_e_68d6a020cf448323b1c749ab7231c648