### PR TITLE
Resolve e-Stat preset IDs dynamically

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -37,6 +37,8 @@ Streamlit ベースで業種・地域を入力すると、e-Stat API から統�
 ## 拡張ポイント
 
 - `data/sample_queries.json` に統計表 ID やパラメータを追加して用途に応じて拡張できます。
+  `statsDataId` が不明な場合は `statsListParams` と `tableNameKeyword` を指定すると
+  アプリ起動時に自動で解決されます。
 - `services/jsic_mapper.py` の辞書を更新すると、業種の補完精度を高められます。
 - `services/nowcast.py` では月次成長率を渡すことで Nowcast の計算を高度化できます。
 - `services/llm_writer.py` のプロンプトを調整し、生成する文章の粒度やトーンをカスタマイズできます。

--- a/app/data/sample_queries.json
+++ b/app/data/sample_queries.json
@@ -1,8 +1,13 @@
 {
   "economic_census": {
     "name": "経済センサス-活動調査（事業所数）",
-    "statsDataId": "0000000000000000000000000000",
-    "description": "産業別・都道府県別の事業所数。サンプルIDのため必要に応じて更新してください。",
+    "statsDataId": null,
+    "statsListParams": {
+      "searchWord": "経済センサス 活動調査 事業所数 産業 都道府県",
+      "surveyYears": "2021"
+    },
+    "tableNameKeyword": "産業（中分類）×都道府県",
+    "description": "産業別・都道府県別の事業所数。statsDataId は自動解決されます。",
     "default_params": {
       "cdCat01": "06",
       "cdArea": "40",
@@ -11,8 +16,13 @@
   },
   "monthly_retail": {
     "name": "商業動態統計（月次小売販売額）",
-    "statsDataId": "1111111111111111111111111111",
-    "description": "関連する月次販売額指数。Nowcast補正で利用。サンプルIDです。",
+    "statsDataId": null,
+    "statsListParams": {
+      "searchWord": "商業動態統計 月次 小売業 販売額",
+      "surveyYears": "2023"
+    },
+    "tableNameKeyword": "小売業 販売額",
+    "description": "関連する月次販売額指数。Nowcast補正で利用。statsDataId は自動解決されます。",
     "default_params": {
       "cdCat01": "06",
       "cdArea": "00000",
@@ -21,8 +31,13 @@
   },
   "household_survey": {
     "name": "家計調査（品目別支出）",
-    "statsDataId": "2222222222222222222222222222",
-    "description": "関連消費支出の参照用指標。サンプルIDです。",
+    "statsDataId": null,
+    "statsListParams": {
+      "searchWord": "家計調査 品目別 支出",
+      "surveyYears": "2023"
+    },
+    "tableNameKeyword": "品目分類",
+    "description": "関連消費支出の参照用指標。statsDataId は自動解決されます。",
     "default_params": {
       "cdCat01": "06",
       "time": "2012-2023"


### PR DESCRIPTION
## Summary
- add an e-Stat getStatsList lookup helper so presets can resolve statsDataId dynamically
- update the Streamlit workflow to retry with an auto-resolved statsDataId when preset values are invalid
- refresh preset metadata and documentation to describe the new auto-resolution behaviour

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d6a3dfa2fc832382d39174030bdf4d