### PR TITLE
Refine Streamlit session handling for single-click interactions

### DIFF
--- a/app/components/layout.py
+++ b/app/components/layout.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Tuple
+from typing import Dict
 
 import streamlit as st
 
@@ -11,104 +11,121 @@ FOOTER_TEXT = "統計出典：政府統計の総合窓口（e-Stat）。二次�
 
 
 def sidebar_controls(
-    presets: Dict[str, Dict[str, str]]
-) -> Tuple[str, str, str, Dict[str, str], Tuple[int, int], bool, str]:
-    """Render sidebar controls and return user selections."""
+    presets: Dict[str, Dict[str, str]],
+    *,
+    on_submit,
+) -> None:
+    """Render sidebar controls and delegate submission to a callback."""
 
     st.sidebar.header("分析条件")
-    industry = st.sidebar.text_input("業種（フリーワード）", "美容室")
-    prefecture = st.sidebar.selectbox(
-        "地域（都道府県）",
-        [
-            "全国",
-            "北海道",
-            "青森県",
-            "岩手県",
-            "宮城県",
-            "秋田県",
-            "山形県",
-            "福島県",
-            "茨城県",
-            "栃木県",
-            "群馬県",
-            "埼玉県",
-            "千葉県",
-            "東京都",
-            "神奈川県",
-            "新潟県",
-            "富山県",
-            "石川県",
-            "福井県",
-            "山梨県",
-            "長野県",
-            "岐阜県",
-            "静岡県",
-            "愛知県",
-            "三重県",
-            "滋賀県",
-            "京都府",
-            "大阪府",
-            "兵庫県",
-            "奈良県",
-            "和歌山県",
-            "鳥取県",
-            "島根県",
-            "岡山県",
-            "広島県",
-            "山口県",
-            "徳島県",
-            "香川県",
-            "愛媛県",
-            "高知県",
-            "福岡県",
-            "佐賀県",
-            "長崎県",
-            "熊本県",
-            "大分県",
-            "宮崎県",
-            "鹿児島県",
-            "沖縄県",
-        ],
-        index=41,
-    )
-    preset_key = st.sidebar.selectbox(
-        "統計表プリセット",
-        list(presets.keys()),
-        format_func=lambda key: presets[key]["name"],
-    )
-    period = st.sidebar.slider("期間（年）", 2009, 2023, (2012, 2021))
-    nowcast = st.sidebar.toggle("Nowcast推定を表示", value=True)
+    prefecture_options = [
+        "全国",
+        "北海道",
+        "青森県",
+        "岩手県",
+        "宮城県",
+        "秋田県",
+        "山形県",
+        "福島県",
+        "茨城県",
+        "栃木県",
+        "群馬県",
+        "埼玉県",
+        "千葉県",
+        "東京都",
+        "神奈川県",
+        "新潟県",
+        "富山県",
+        "石川県",
+        "福井県",
+        "山梨県",
+        "長野県",
+        "岐阜県",
+        "静岡県",
+        "愛知県",
+        "三重県",
+        "滋賀県",
+        "京都府",
+        "大阪府",
+        "兵庫県",
+        "奈良県",
+        "和歌山県",
+        "鳥取県",
+        "島根県",
+        "岡山県",
+        "広島県",
+        "山口県",
+        "徳島県",
+        "香川県",
+        "愛媛県",
+        "高知県",
+        "福岡県",
+        "佐賀県",
+        "長崎県",
+        "熊本県",
+        "大分県",
+        "宮崎県",
+        "鹿児島県",
+        "沖縄県",
+    ]
 
-    default_api_key = ""
-    if "estat_api_key" in st.session_state:
-        default_api_key = st.session_state["estat_api_key"]
-    elif "ESTAT_APP_ID" in st.secrets:
-        default_api_key = st.secrets["ESTAT_APP_ID"]
-    else:
-        from os import getenv
+    if st.session_state["_prefecture_widget"] not in prefecture_options:
+        st.session_state["_prefecture_widget"] = prefecture_options[0]
 
-        default_api_key = getenv("ESTAT_APP_ID", "")
+    with st.sidebar.form("analysis_controls"):
+        st.text_input(
+            "業種（フリーワード）",
+            value=st.session_state["_industry_widget"],
+            key="_industry_widget",
+        )
+        st.selectbox(
+            "地域（都道府県）",
+            prefecture_options,
+            index=prefecture_options.index(st.session_state["_prefecture_widget"]),
+            key="_prefecture_widget",
+        )
+        preset_keys = list(presets.keys())
+        if st.session_state["_preset_widget"] not in presets:
+            st.session_state["_preset_widget"] = preset_keys[0]
+        st.selectbox(
+            "統計表プリセット",
+            preset_keys,
+            format_func=lambda key: presets[key]["name"],
+            index=preset_keys.index(st.session_state["_preset_widget"]),
+            key="_preset_widget",
+        )
+        st.slider(
+            "期間（年）",
+            2009,
+            2023,
+            value=st.session_state["_period_widget"],
+            key="_period_widget",
+        )
+        st.toggle(
+            "Nowcast推定を表示",
+            value=st.session_state["_nowcast_widget"],
+            key="_nowcast_widget",
+        )
+        st.text_input(
+            "e-Stat APIキー",
+            value=st.session_state["_estat_api_key_widget"],
+            key="_estat_api_key_widget",
+            type="password",
+            help="e-StatのアプリケーションIDを入力してください。",
+        )
+        st.form_submit_button("分析する", type="primary", on_click=on_submit)
 
-    api_key = st.sidebar.text_input(
-        "e-Stat APIキー",
-        value=default_api_key,
-        type="password",
-        help="e-StatのアプリケーションIDを入力してください。",
-    )
-    api_key = api_key.strip()
-    if api_key:
-        st.session_state["estat_api_key"] = api_key
-    elif "estat_api_key" in st.session_state and st.session_state["estat_api_key"]:
-        api_key = st.session_state["estat_api_key"]
     advanced = st.sidebar.expander("高度な設定")
     with advanced:
         st.caption("sample_queries.json を編集することで統計表を追加できます。")
-        stats_id = presets[preset_key].get("statsDataId") or "未設定"
+        preview_preset_key = st.session_state.get("_preset_widget", st.session_state.get("preset_key"))
+        if preview_preset_key not in presets:
+            preview_preset_key = list(presets.keys())[0]
+        stats_id = presets[preview_preset_key].get("statsDataId") or "未設定"
         st.text_input("statsDataId", value=str(stats_id), disabled=True)
-        st.json(presets[preset_key])
+        st.json(presets[preview_preset_key])
     st.sidebar.markdown("---")
     st.sidebar.caption(FOOTER_TEXT)
-    return industry, prefecture, preset_key, presets[preset_key], period, nowcast, api_key
 
 
 def footer() -> None:


### PR DESCRIPTION
## Summary
- wrap sidebar inputs in a form with dedicated widget keys and callback-driven submission to avoid double triggering
- centralize session state initialization, separating widget values from app state and forcing a rerun after mutations
- surface a clear prompt when the analysis has not been executed to keep the UI stable between runs

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dbf16b9ab083239eff62746323681e